### PR TITLE
ci: Fix remove repository owner hardcoded test value

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,7 +106,6 @@ jobs:
         with:
           app-id: ${{ vars.GHA_BOT_APP_ID }}
           private-key: ${{ secrets.GHA_BOT_PRIVATE_KEY }}
-          owner: jbonnier
           repositories: |
             docker-terragrunt
 


### PR DESCRIPTION
GitHub Issue: # n/a

## Proposed Changes

Removed repository owner test hard-coded value

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build or CI related changes
- [ ] Documentation content changes
- [ ] Other, please describe:


## What is the current behavior?

The `git` jobs fails due to erroneous repository owner from fork.

## What is the new behavior?

The repository owner is inferred automatically, so the Workflow should pass.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [x] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

## Other information

n/a