### PR TITLE
chore: Change Docker tag format, add labels to Docker artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,8 +84,11 @@ jobs:
           context: .
           push: false
           tags: |
-            ${{ vars.DOCKER_REPOSITORY_NAME }}:0.0.0-${{ needs.versions.outputs.new-tag }}-ubuntu-jammy-build-${{ github.run_id }}.${{ github.run_number }}
+            ${{ vars.DOCKER_REPOSITORY_NAME }}:0.0.0-${{ needs.versions.outputs.new-tag }}
             ${{ vars.DOCKER_REPOSITORY_NAME }}:latest
+          labels: |
+            io.jblab.build.number=${{ github.run_id }}.${{ github.run_number }}
+            io.jblab.git.repository=${{ github.repositoryUrl }}
           build-args: |
             TERRAFORM_VERSION=${{ needs.versions.outputs.tf-version }}
             TERRAGRUNT_VERSION=${{ needs.versions.outputs.tg-version }}
@@ -202,8 +205,11 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ vars.DOCKER_REPOSITORY_NAME }}:${{ needs.git.outputs.new-tag }}-${{ needs.versions.outputs.new-tag }}-ubuntu-jammy-build-${{ github.run_id }}.${{ github.run_number }}
+            ${{ vars.DOCKER_REPOSITORY_NAME }}:0.0.0-${{ needs.versions.outputs.new-tag }}
             ${{ vars.DOCKER_REPOSITORY_NAME }}:latest
+          labels: |
+            io.jblab.build.number=${{ github.run_id }}.${{ github.run_number }}
+            io.jblab.git.repository=${{ github.repositoryUrl }}
           build-args: |
             TERRAFORM_VERSION=${{ needs.versions.outputs.tf-version }}
             TERRAGRUNT_VERSION=${{ needs.versions.outputs.tg-version }}


### PR DESCRIPTION
GitHub Issue: n/a

## Proposed Changes

- Change the format of the Docker tag for a less cluttered one. 
- Add labels to the built artifact.

---

- [ ] Bug fix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build or CI related changes
- [ ] Documentation content changes
- [x] Other, please describe:

Small improvement, not really a feature

## What is the current behavior?

The Docker tags contain the OS information and the GitHub build number.

## What is the new behavior?

The Docker tags now contain only the semver and the Terraform and Terragrunt versions.
A label has been added with the build number and another with the Git repository.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [X] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).


## Other information

