### PR TITLE
ci: Fix unnecessary repository URL in .releaserc

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,4 @@
 branches: [ main ]
-repositoryUrl: "https://github.com/jbonnier/docker-terragrunt.git",
 tagFormat: ${version}
 plugins:
   - - '@semantic-release/commit-analyzer'


### PR DESCRIPTION
GitHub Issue: n/a

## Proposed Changes

The changes in this PR remove the unnecessary `repositoryURL` from the `.releaserc` file

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build or CI related changes
- [ ] Documentation content changes
- [ ] Other, please describe:

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [x] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

## Other information

n/a