### PR TITLE
ci: Push commit only if Dockerfile has changed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,7 +149,7 @@ jobs:
         run: |
           git checkout main
           git add Dockerfile
-          if ! git diff-index --quiet HEAD --; then
+          if ! git diff-index --quiet HEAD -- Dockerfile; then
             git commit -m "chore(tool-versions): Update Dockerfile with new Terraform and Terragrunt versions [skip ci]"
             git push origin main
           fi


### PR DESCRIPTION
GitHub Issue: n/a

## Proposed Changes

Yet another CI fix so it pushes back changes only if the `Dockerfile` has changed.

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build or CI related changes
- [ ] Documentation content changes
- [ ] Other, please describe:

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [x] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).


## Other information

n/a