### PR TITLE
ci: Fix grep expression to get new tag/release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,7 +158,7 @@ jobs:
         id: semantic
         run: |
           npx semantic-release 2>&1 | tee release_output.txt
-          TAG=$(grep -oP "v\d+\.\d+\.\d+" release_output.txt | head -1)
+          TAG=$(tail -1 release_output.txt | grep -oP "\d+\.\d+\.\d+")
           if [[ -n "$TAG" ]]; then
             echo "NEW_TAG=$TAG" >> $GITHUB_ENV
           fi


### PR DESCRIPTION
GitHub Issue: n/a

## Proposed Changes

Fix the grep expression to get the new tag/release

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build or CI related changes
- [ ] Documentation content changes
- [ ] Other, please describe:

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [x] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

## Other information
 
n/a