### PR TITLE
docs: Update "build" file name in README for badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docker-terragrunt <img src="https://assets.jblab.info/2024/03/17/jblab-logo-with-text.26da23672fc44c17078dc8ce2ff8495ddb190163.webp" alt="jblab logo" width="120" align="right" style="max-width: 100%">
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square)](LICENSE) [![Latest Release](https://img.shields.io/github/release/jblab/docker-terragrunt.svg?style=flat-square)](https://github.com/jblab/docker-terragrunt/releases/latest) ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/jblab/docker-terragrunt/main.yml?style=flat-square)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square)](LICENSE) [![Latest Release](https://img.shields.io/github/release/jblab/docker-terragrunt.svg?style=flat-square)](https://github.com/jblab/docker-terragrunt/releases/latest) ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/jblab/docker-terragrunt/main.yaml?style=flat-square)
 
 This Docker image includes Terraform and Terragrunt, which are essential tools for managing infrastructure as code. It
 can be used for local development to avoid managing different versions of these tools on your system or as part of your


### PR DESCRIPTION
GitHub Issue: n/a

## Proposed Changes

This is a fix to make the build badge on the README reflect file name change with of `main.yaml`.

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build or CI related changes
- [x] Documentation content changes
- [ ] Other, please describe:


## What is the current behavior?

The build badge is broken.

## What is the new behavior?

The build badge works.


## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [x] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

## Other information

n/a