### PR TITLE
feat: Add target to Docker build so we can publish two different images

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -27,6 +27,10 @@ on:
         description: 'The environment for the secrets'
         type: string
         default: ''
+      target:
+        description: 'The Dockerfile stage to target'
+        type: string
+        default: ''
     secrets:
       DOCKER_USERNAME:
         required: true
@@ -58,6 +62,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_image }}
+          target: ${{ inputs.target }}
           tags: |
             ${{ vars.DOCKER_REPOSITORY_NAME }}:${{ inputs.git_tag }}-${{ inputs.version_tag }}
             ${{ vars.DOCKER_REPOSITORY_NAME }}:latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -175,4 +175,20 @@ jobs:
       git_tag: ${{ needs.git.outputs.new-tag }}
       tf_version: ${{ needs.versions.outputs.tf-version }}
       tg_version: ${{ needs.versions.outputs.tg-version }}
+      target: 'base'
+    secrets: inherit
+
+  build_ado:
+    name: Build and Push Docker Image for Azure DevOps
+    needs: [ versions, ci, git ]
+    if: needs.versions.outputs.new-tag && needs.versions.outputs.tf-version && needs.versions.outputs.tg-version && needs.git.outputs.new-tag
+    uses: ./.github/workflows/docker-build.yaml
+    with:
+      push_image: true
+      environment: main
+      version_tag: ${{ needs.versions.outputs.new-tag }}-azdo
+      git_tag: ${{ needs.git.outputs.new-tag }}
+      tf_version: ${{ needs.versions.outputs.tf-version }}
+      tg_version: ${{ needs.versions.outputs.tg-version }}
+      target: 'ado_builder'
     secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ RUN set -e; \
     chmod +x /usr/local/bin/terragrunt; \
     terragrunt -version
 
+ENTRYPOINT []
+
 # ----------------------------------------------------------------------------------------------------------------------
 # DEV
 # ----------------------------------------------------------------------------------------------------------------------
@@ -64,7 +66,5 @@ RUN set -eu; \
     apt-get update; \
     apt-get install nodejs -y; \
     rm -rf /var/lib/apt/lists/*;
-
-ENTRYPOINT []
 
 LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/node"


### PR DESCRIPTION
GitHub Issue: n/a

## Proposed Changes

This PR decouples the Docker base image from the Azure DevOps pipeline builder so we can benefit from a lighter image on other CI/CD platforms.

- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build or CI related changes
- [ ] Documentation content changes
- [ ] Other, please describe:


## What is the current behavior?

Only one image is published to the Docker Hub.

## What is the new behavior?

There are two versions of the Docker image published to the Docker Hub, one with NodeJs for Azure DevOps and one without it.


## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [x] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).


## Other information

n/a
