### PR TITLE
feat: Remove unnecessary tools from base image

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -178,6 +178,21 @@ jobs:
       target: 'base'
     secrets: inherit
 
+  build_dev:
+    name: Build and Push Docker Image for Azure DevOps
+    needs: [ versions, ci, git ]
+    if: needs.versions.outputs.new-tag && needs.versions.outputs.tf-version && needs.versions.outputs.tg-version && needs.git.outputs.new-tag
+    uses: ./.github/workflows/docker-build.yaml
+    with:
+      push_image: true
+      environment: main
+      version_tag: ${{ needs.versions.outputs.new-tag }}-dev-tools
+      git_tag: ${{ needs.git.outputs.new-tag }}
+      tf_version: ${{ needs.versions.outputs.tf-version }}
+      tg_version: ${{ needs.versions.outputs.tg-version }}
+      target: 'dev'
+    secrets: inherit
+
   build_ado:
     name: Build and Push Docker Image for Azure DevOps
     needs: [ versions, ci, git ]

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,5 +1,5 @@
 # Breaking Changes
 
-## x.x.x
+## 2.0.0
 
-Breaking change description
+- Remove extra tools from default (base) image.

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN set -eu \
 
 RUN set -eu; \
     apt update; \
-    apt install -y --no-install-recommends bash git openssh-client vim tree make graphviz curl ca-certificates unzip; \
+    apt install -y --no-install-recommends git openssh-client curl ca-certificates unzip; \
     rm -rf /var/lib/apt/lists/*;
 
 RUN set -eu; \
@@ -44,6 +44,11 @@ ENTRYPOINT []
 # ----------------------------------------------------------------------------------------------------------------------
 FROM base AS dev
 
+RUN set -eu; \
+    apt update; \
+    apt install -y --no-install-recommends bash vim tree make graphviz; \
+    rm -rf /var/lib/apt/lists/*;
+
 USER terragrunt
 
 STOPSIGNAL SIGKILL
@@ -59,7 +64,7 @@ ARG NODE_MAJOR="20"
 
 RUN set -eu; \
     apt-get update; \
-    apt-get install -y ca-certificates gnupg; \
+    apt-get install -y ca-certificates gnupg bash; \
     mkdir -p /etc/apt/keyrings ; \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \

--- a/compose.yml
+++ b/compose.yml
@@ -5,4 +5,4 @@ services:
       dockerfile: Dockerfile
       target: dev
     volumes:
-      - ./files/.bashrc.sh:/home/terragrunt/.bashrc:ro
+      - ./files/bashrc.sh:/home/terragrunt/.bashrc:ro


### PR DESCRIPTION
GitHub Issue: n/a

## Proposed Changes

- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build or CI related changes
- [ ] Documentation content changes
- [ ] Other, please describe:


## What is the current behavior?

The `base` and the `ado_builder`  images contain unnecessary extra tools.


## What is the new behavior?

The `base` and the `ado_builder`  images do NOT contain unnecessary extra tools anymore.


## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [x] Commits have been squashed (if applicable).
- [x] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

BREAKING CHANGE: some tools are no longer included in the base image


## Other information

n/a
