### PR TITLE
feat: Change the entrypoint of the `dev` target for a command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN set -eu; \
 USER terragrunt
 
 STOPSIGNAL SIGKILL
-ENTRYPOINT ["sleep", "infinity"]
+CMD ["sleep", "infinity"]
 
 # ----------------------------------------------------------------------------------------------------------------------
 # ADO Builder target, this image should be pushed to a Docker registry and used by the Azure DevOps Build Agent.


### PR DESCRIPTION
GitHub Issue: n/a 

## Proposed Changes

- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build or CI related changes
- [ ] Documentation content changes
- [ ] Other, please describe:


## What is the current behavior?

The `dev` target uses an entry point for the PID 1.


## What is the new behavior?

The `dev` target uses a command for the PID 1.


## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [x] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

## Other information

n/a