### PR TITLE
ci: Update how Docker tags are set

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -7,8 +7,8 @@ on:
         description: 'Whether to push the image or not'
         required: true
         type: boolean
-      git_tag:
-        description: 'The Git Semver tag'
+      tags:
+        description: 'The Docker image tags to be used (one per line or comma-separated)'
         required: true
         type: string
       tf_version:
@@ -17,10 +17,6 @@ on:
         type: string
       tg_version:
         description: 'The Terragrunt version'
-        required: true
-        type: string
-      version_tag:
-        description: 'The Docker image tag'
         required: true
         type: string
       environment:
@@ -63,9 +59,7 @@ jobs:
           context: .
           push: ${{ inputs.push_image }}
           target: ${{ inputs.target }}
-          tags: |
-            ${{ vars.DOCKER_REPOSITORY_NAME }}:${{ inputs.git_tag }}-${{ inputs.version_tag }}
-            ${{ vars.DOCKER_REPOSITORY_NAME }}:latest
+          tags: ${{ inputs.tags }}
           labels: |
             io.jblab.build.number=${{ github.run_id }}.${{ github.run_number }}
             io.jblab.git.repository=${{ github.repositoryUrl }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -171,10 +171,11 @@ jobs:
     with:
       push_image: true
       environment: main
-      version_tag: ${{ needs.versions.outputs.new-tag }}
-      git_tag: ${{ needs.git.outputs.new-tag }}
       tf_version: ${{ needs.versions.outputs.tf-version }}
       tg_version: ${{ needs.versions.outputs.tg-version }}
+      tags: |
+        ${{ vars.DOCKER_REPOSITORY_NAME }}:${{ needs.git.outputs.new-tag }}-${{ needs.versions.outputs.new-tag }}
+        ${{ vars.DOCKER_REPOSITORY_NAME }}:latest
       target: 'base'
     secrets: inherit
 
@@ -186,11 +187,10 @@ jobs:
     with:
       push_image: true
       environment: main
-      version_tag: ${{ needs.versions.outputs.new-tag }}-dev-tools
-      git_tag: ${{ needs.git.outputs.new-tag }}
       tf_version: ${{ needs.versions.outputs.tf-version }}
       tg_version: ${{ needs.versions.outputs.tg-version }}
       target: 'dev'
+      tags: ${{ vars.DOCKER_REPOSITORY_NAME }}:${{ needs.git.outputs.new-tag }}-${{ needs.versions.outputs.new-tag }}-dev-tools
     secrets: inherit
 
   build_ado:
@@ -201,9 +201,8 @@ jobs:
     with:
       push_image: true
       environment: main
-      version_tag: ${{ needs.versions.outputs.new-tag }}-azdo
-      git_tag: ${{ needs.git.outputs.new-tag }}
       tf_version: ${{ needs.versions.outputs.tf-version }}
       tg_version: ${{ needs.versions.outputs.tg-version }}
       target: 'ado_builder'
+      tags: ${{ vars.DOCKER_REPOSITORY_NAME }}:${{ needs.git.outputs.new-tag }}-${{ needs.versions.outputs.new-tag }}-azdo
     secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,13 @@ ARG TERRAGRUNT_VERSION=0.72.1
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 
-RUN set -eu \
-    && addgroup --gid $GROUP_ID --system terragrunt \
-    && adduser \
-        --disabled-password \
-        --system \
-        --home /home/terragrunt \
+RUN set -eu; \
+    groupadd --gid $GROUP_ID --system terragrunt; \
+    useradd \
         --uid $USER_ID \
         --gid $GROUP_ID \
+        --home /home/terragrunt \
+        --system \
         --shell /sbin/nologin \
         terragrunt
 
@@ -46,7 +45,7 @@ FROM base AS dev
 
 RUN set -eu; \
     apt update; \
-    apt install -y --no-install-recommends bash vim tree make graphviz; \
+    apt install -y --no-install-recommends vim tree make graphviz; \
     rm -rf /var/lib/apt/lists/*;
 
 USER terragrunt
@@ -64,7 +63,7 @@ ARG NODE_MAJOR="20"
 
 RUN set -eu; \
     apt-get update; \
-    apt-get install -y ca-certificates gnupg bash; \
+    apt-get install -y ca-certificates gnupg; \
     mkdir -p /etc/apt/keyrings ; \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \


### PR DESCRIPTION
GitHub Issue: n/a

## Proposed Changes

- [ ] Bug fix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build or CI related changes
- [ ] Documentation content changes
- [ ] Other, please describe:


## What is the current behavior?

The `latest` tag is set in the `docker-build.yaml`  file resulting in the `azdo` variant being tag latest.

## What is the new behavior?

Docker tags are determined in the `main.yaml` resulting in the base image being tag latest.


## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [x] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

## Other information

n/a