### PR TITLE
fix: Update forgotten `ci` job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -71,10 +71,9 @@ jobs:
     uses: ./.github/workflows/docker-build.yaml
     with:
       push_image: false
-      git_tag: 0.0.0
       tf_version: ${{ needs.versions.outputs.tf-version }}
       tg_version: ${{ needs.versions.outputs.tg-version }}
-      version_tag: ${{ needs.versions.outputs.new-tag }}
+      tags: ${{ vars.DOCKER_REPOSITORY_NAME }}:0.0.0-${{ needs.versions.outputs.new-tag }}
     secrets:
       DOCKER_USERNAME: ''
       DOCKER_TOKEN: ''


### PR DESCRIPTION
GitHub Issue: n/a

## Proposed Changes

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build or CI related changes
- [ ] Documentation content changes
- [ ] Other, please describe:


## What is the current behavior?

The build fails due to a forgotten job.

## What is the new behavior?

The build should pass.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [x] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

## Other information

n/a