### PR TITLE
fix: Remove "v" prefix from Terraform version number

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,6 +26,10 @@ jobs:
         run: |
           CURRENT_VERSION=$(grep -oP '(?<=TERRAFORM_VERSION=).*' Dockerfile)
           LATEST_VERSION=$(curl --silent "https://checkpoint-api.hashicorp.com/v1/check/terraform?current_version=0.0.0" | grep -Po '(?<=current_version":")[^"]*')
+          if [[ $LATEST_VERSION == v* ]]; then
+            # Remove the v from the version number
+            LATEST_VERSION=${LATEST_VERSION:1}
+          fi
           if [ "$CURRENT_VERSION" != "$LATEST_VERSION" ]; then
             echo "NEW_TF_VERSION=$LATEST_VERSION" >> $GITHUB_ENV
             echo >&2 "New Terraform version found: $LATEST_VERSION"


### PR DESCRIPTION
GitHub Issue: n/a

## Proposed Changes

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build or CI related changes
- [ ] Documentation content changes
- [ ] Other, please describe:


## What is the current behavior?

Terraform added a "v" prefix to its version number, but not in the URL, causing the Docker build command to fail.

## What is the new behavior?

We now strip the "v" prefix from the version number, if present, to ensure the build succeeds.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [x] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

## Other information

n/a
