### PR TITLE
ci: replace deprecated app-id input with client-id for actions/create…

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.GHA_BOT_APP_ID }}
+          client-id: ${{ vars.GHA_BOT_CLIENT_ID }}
           private-key: ${{ secrets.GHA_BOT_PRIVATE_KEY }}
           repositories: |
             docker-terragrunt
@@ -171,7 +171,7 @@ jobs:
       - uses: jblab/.github/.github/actions/release@main
         id: release
         with:
-          app-id: ${{ vars.GHA_BOT_APP_ID }}
+          app-client-id: ${{ vars.GHA_BOT_CLIENT_ID }}
           repository: ${{ github.repository }}
           app-private-key: ${{ secrets.GHA_BOT_PRIVATE_KEY }}
           skip-checkout: true


### PR DESCRIPTION
GitHub Issue: n/a

## Proposed Changes

Replace the deprecated `app-id` input with `client-id` for  `actions/create-github-app-token`

- [ ] Bug fix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build or CI related changes
- [ ] Documentation content changes
- [ ] Other, please describe:

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [x] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

## Other information

n/a