### PR TITLE
fix: update OCI label revision to use Git SHA instead of Git ref

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -76,7 +76,7 @@ jobs:
             io.jblab.build.number=${{ github.run_id }}.${{ github.run_number }}
             io.jblab.git.repository=${{ github.repositoryUrl }}
             org.opencontainers.image.version=${{ inputs.version }}
-            org.opencontainers.image.revision=${{ github.ref }}
+            org.opencontainers.image.revision=${{ github.sha }}
           build-args: |
             TERRAFORM_VERSION=${{ inputs.tf_version }}
             TERRAGRUNT_VERSION=${{ inputs.tg_version }}


### PR DESCRIPTION
GitHub Issue: n/a

## Proposed Changes

Use Git SHA instead of Git Ref for OCI label revision.

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build or CI related changes
- [ ] Documentation content changes
- [ ] Other, please describe:


## What is the current behavior?

The `org.opencontainers.image.revision`  is always `refs/heads/main`.


## What is the new behavior?

The `org.opencontainers.image.revision`  should now be the SHA of the commit used to build.


## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [x] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

